### PR TITLE
fix: update webpack-cli initialization command

### DIFF
--- a/Labs/Lab 1 - TypeScript Webresources.md
+++ b/Labs/Lab 1 - TypeScript Webresources.md
@@ -61,7 +61,7 @@ To build your TypeScript you can use the TypeScript compiler `tsc`  - however th
 
    ```powershell
    npm install --save-dev webpack webpack-cli @webpack-cli/generators
-   npx webpack-cli init
+   npx create-new-webpack-app
    ```
 
 1. Answer the questions as follows:


### PR DESCRIPTION
This pull request includes a small change to the `Labs/Lab 1 - TypeScript Webresources.md` file. The change updates the command used to initialize a new webpack project.

link to webpack-cli changelog: https://github.com/webpack/webpack-cli/blob/master/CHANGELOG.md